### PR TITLE
use correct framework

### DIFF
--- a/BaseTests/CodexMicroORM.BaseTests.csproj
+++ b/BaseTests/CodexMicroORM.BaseTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CodexMicroORM.CodexV1CompatLayer/CodexMicroORM.CodexV1CompatLayer/CodexMicroORM.CodexV1CompatLayer.csproj
+++ b/CodexMicroORM.CodexV1CompatLayer/CodexMicroORM.CodexV1CompatLayer/CodexMicroORM.CodexV1CompatLayer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net80</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <Version>1.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>CodeX Enterprises LLC</Authors>

--- a/CodexMicroORM.Core/CodexMicroORM.Core.csproj
+++ b/CodexMicroORM.Core/CodexMicroORM.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net7;net80</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net7.0;net8.0</TargetFrameworks>
 	<PackageId>CodexMicroORM.Core</PackageId>
 	<Version>1.3.0</Version>
 	<Authors>CodeX Enterprises LLC</Authors>

--- a/CodexMicroORM.SQLServer/CodexMicroORM.SQLServer.csproj
+++ b/CodexMicroORM.SQLServer/CodexMicroORM.SQLServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net7;net80</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net7.0;net8.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Version>1.2.0</Version>

--- a/README.md
+++ b/README.md
@@ -485,13 +485,13 @@ Want to see even more? Share, watch, clone, blog, post links to this project - a
 * 1.1.0 - November 2022
 	* Add: ExecuteWithMaxWaitAsync, DeepCopyList, DBSaveTransactional, ReconcileEntitySetToEntitySet - some extension method goodies added, minor cleanup
 	* Add: IndexedSet - a highly read-efficient collection that can "auto-index" itself based on linq (to object) queries run against it. Inherits from EntitySet so can be used interchangeably to a large degree. Supports both equality and range indexes. Requires adding C5 package ref. Moved this from ZDB project (pre-release) to CEF as this can be considered core plumbing with broad applicability. More details to be included here later.
-	* Add: net7 targetting
+	* Add: net7.0 targetting
 	* Fix: minor fixes (e.g. some disposal cleanup, etc.)
 * 1.2.0 - June 2024
 	* Add: Recursive option for CEF.NewObject (making an explicit opt-in, due to performance)
 	* Add: Retrieve Identity settings/options, including Globals.DefaultRetrievalIdentityMode, Globals.FrameworkWarningHandler, AllowRetrievalDups (addresses where default behavior could be "surprising" when doing custom queries that return duplicates of key value for entity retrieved into)
 	* Add: New unit tests related to IndexedSet, retrieve identity, etc.
-	* Change: net80 targeting, cleanup related to .NET Core, various updates to dependencies (latest)
+	* Change: net8.0 targeting, cleanup related to .NET Core, various updates to dependencies (latest)
 	* Change: Various syntax updates to support latest C# features, unit tests cleanup (some deprecated for now, see notes in DBOps.cs, 100% pass rate)
 * 1.3.0 - June 2024
 	* Add: PoolableItemWrapper to Core - supports any object that can be pooled (useful for scenarios where you want to avoid object creation overhead)


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks